### PR TITLE
also print what package is vulnerable to a CVE

### DIFF
--- a/cve-check
+++ b/cve-check
@@ -13,7 +13,7 @@ pull_cves() {
 		echo "This script requires xsltproc to be available, install libxslt." >&2
 		exit 1
 	fi
-	
+
 	if [ ! $WGETCMD ]
 	then
 		WGETCMD="wget"
@@ -171,6 +171,6 @@ do
 		fi
 
 		# If we reached here we are vulnerable
-		printf "CVE: %s SEVERITY: %s\\n" "$cve" "$sev"
+		printf "Package %s is affected by CVE: %s SEVERITY: %s\\n" "$pkg" "$cve" "$sev"
 	done
 done


### PR DESCRIPTION
makes it a lot easier to run the script on all void packages at once & removed trailing whitespace